### PR TITLE
Add more details when failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+<!-- markdownlint-disable no-duplicate-header -->
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1]
+
+* Detail execution problems when `spawnWithLogging` wrapper fails
+* Added CHANGELOG.md
+
+## [0.4.0]
+
+* Previous release

--- a/index.js
+++ b/index.js
@@ -56,19 +56,23 @@ function getOptionsWithDefaults (options, manifest) {
 async function spawnWithLogging (options, command, args, allowFail) {
   return new Promise((resolve, reject) => {
     logger(`$ ${command} ${args.join(' ')}`)
+    const output = []
     const child = childProcess.spawn(command, args, { cwd: options['working-dir'] })
     child.stdout.on('data', (data) => {
+      output.push(data)
       logger(`1> ${data}`)
     })
     child.stderr.on('data', (data) => {
+      output.push(data)
       logger(`2> ${data}`)
     })
     child.on('error', (error) => {
+      logger(`error - ${error.message} ${error.stack}`)
       reject(error)
     })
     child.on('close', (code) => {
       if (!allowFail && code !== 0) {
-        reject(new Error(`${command} failed with status code ${code}`))
+        reject(new Error(`${command} failed with status code ${code} ${output.join(' ')}`))
       }
       resolve(code === 0)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malept/flatpak-bundler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A small utility for packing files in a flatpak.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi, if you consider it useful, please have a look

I was trying to make an `electron-builder` flatpak bundle for https://github.com/iongion/podman-desktop-companion but I am rather new to the world of flatpak, it was failing, but I did not know what / why was failing. 

1. I had to have electron-builder output first `"DEBUG": "electron-builder"` (obscure in itself)
2. After attempting to create a flatpak bunde, errors where like this:
```exited          command=app-builder code=0 pid=353778 out={"icons":[{"file":"/home/istoica/Workspace/podman-desktop-companion/src/app/resources/icons/appIcon.svg","size":1024}],"isFallback":false}
  • async task error  error=flatpak-builder failed with status code 1
  ⨯ flatpak-builder failed with status code 1  failedTask=build stackTrace=Error: flatpak-builder failed with status code 1
```

With the proposed fix, the same error show as this

```
  • async task error  error=flatpak-builder failed with status code 1 Downloading sources
Initializing build dir
error: 'iongion.podman_desktop_companion' is not a valid application name: Names must contain at least 2 periods
Error: Child process exited with code 1

  ⨯ flatpak-builder failed with status code 1 Downloading sources
Initializing build dir
error: 'iongion.podman_desktop_companion' is not a valid application name: Names must contain at least 2 periods
Error: Child process exited with code 1
  failedTask=build stackTrace=Error: flatpak-builder failed with status code 1 Downloading sources
Initializing build dir
error: 'iongion.podman_desktop_companion' is not a valid application name: Names must contain at least 2 periods
Error: Child process exited with code 1
```

I then was able to realize that the `appId` is not proper for flatpak (it was ok for exe, dmg, appimage, rpm, deb, snap)

What do you think ?